### PR TITLE
Fix description to support setuptools v59.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='flake8-self',
     py_modules=['flake8_self'],
     version=__version__,
-    description=open("README.md").readlines()[4],
+    description=open("README.md").readlines()[4].strip().replace("\n", " "),
     long_description=open("README.md").read(),
     long_description_content_type='text/markdown',
     keywords='private access self linting flake8',


### PR DESCRIPTION
The description metadata field is not allowed to contain newline characters.

- https://setuptools.pypa.io/en/latest/history.html#v59-0-0
- https://github.com/pypa/setuptools/pull/2870

This is a quick fix to ensure that the description is a single line.